### PR TITLE
Fix for now Status field on SiteTree in later versions of SS

### DIFF
--- a/code/ZendSearchLuceneSearchable.php
+++ b/code/ZendSearchLuceneSearchable.php
@@ -298,7 +298,7 @@ class ZendSearchLuceneSearchable extends DataExtension {
         // Default to filtering out unpublished and unsearchable SiteTree objects
         $this->classConfig = array(
             'index_filter' => $this->owner->is_a('SiteTree') 
-                ? "\"Status\" = 'Published' AND \"ShowInSearch\" = 1"
+                ? "\"ShowInSearch\" = 1"
                 : ''
         );
         if ( ! $config ) return;


### PR DESCRIPTION
Removed Status field check from the default index_filter as the SiteTree object no longer has a Status field in SS3.

This check is covered by line 409 of ZendSearchLuceneWrapper "if ( $object->is_a('SiteTree') && ! $object->getExistsOnLive() ) continue;"
