### PR TITLE
make getDataArrayFromHits public to allow usage  by custom result page controller

### DIFF
--- a/code/ZendSearchLuceneContentController.php
+++ b/code/ZendSearchLuceneContentController.php
@@ -128,7 +128,7 @@ class ZendSearchLuceneContentController extends Extension {
      * @param   SS_HTTPRequest  $request    The request that generated the search
      * @return  Array                       A custom array containing pagination data.
      */
-    protected function getDataArrayFromHits($hits, $request) {
+    public function getDataArrayFromHits($hits, $request) {
 		$data = array(
 			'Results' => null,
 			'Query' => null,


### PR DESCRIPTION
I ran into the issue that the function getDataArrayFromHits  on the extension is not available when called from a action function from within the page controller. 
Is there a reason for this being protected? 
Thanks.
