### PR TITLE
Fix indexing of dependent pages

### DIFF
--- a/code/ZendSearchLuceneContentController.php
+++ b/code/ZendSearchLuceneContentController.php
@@ -128,7 +128,7 @@ class ZendSearchLuceneContentController extends Extension {
      * @param   SS_HTTPRequest  $request    The request that generated the search
      * @return  Array                       A custom array containing pagination data.
      */
-    protected function getDataArrayFromHits($hits, $request) {
+    public function getDataArrayFromHits($hits, $request) {
 		$data = array(
 			'Results' => null,
 			'Query' => null,

--- a/code/ZendSearchLuceneSearchable.php
+++ b/code/ZendSearchLuceneSearchable.php
@@ -373,6 +373,12 @@ class ZendSearchLuceneSearchable extends DataExtension {
      * Indexes the object after it has been written to the database.
      */
     public function onAfterWrite() {
+        // skip indexing of other pages than current.
+        // otherwise all SiteTree::DependentPages() are newly indexed as well,
+        // which harms performance if there are many internal links to this page
+        if (is_a($this->owner, 'SiteTree') && $this->owner->ID != Controller::curr()->currentPageID()) {
+            return;
+        }
         // Obey index filter rules
         $objs = ZendSearchLuceneWrapper::getAllIndexableObjects($this->owner->ClassName);
         ZendSearchLuceneWrapper::delete($this->owner);
@@ -384,7 +390,6 @@ class ZendSearchLuceneSearchable extends DataExtension {
                 ZendSearchLuceneWrapper::index($this->owner);
             }
         }
-        parent::onAfterWrite();
     }
 
     /**
@@ -392,7 +397,6 @@ class ZendSearchLuceneSearchable extends DataExtension {
      */
     function onAfterDelete() {
         ZendSearchLuceneWrapper::delete($this->owner);
-        parent::onAfterDelete();
     }
 
     /**

--- a/composer.json
+++ b/composer.json
@@ -9,9 +9,8 @@
 	}],
 	"require":
 	{
-		"silverstripe/framework": "3.1.*",
-		"silverstripe/cms": "3.1.*",
-		"composer/installers": "*",
+		"silverstripe/framework": "~3.1",
+		"silverstripe/cms": "~3.1",
 		"silverstripe/queuedjobs": "*"
 	},
 	"extra": {


### PR DESCRIPTION
skip indexing of other pages than current.
otherwise all SiteTree::DependentPages() are newly indexed as well, which harms performance if there are many internal links to this page
